### PR TITLE
This should be a viable fix... maybe.

### DIFF
--- a/src/main/java/frc/robot/commands/test/ResetEncoderPosition.java
+++ b/src/main/java/frc/robot/commands/test/ResetEncoderPosition.java
@@ -1,0 +1,20 @@
+package frc.robot.commands.test;
+
+import edu.wpi.first.wpilibj.command.InstantCommand;
+import frc.robot.subsystems.Arm;
+
+public class ResetEncoderPosition extends InstantCommand {
+
+    private Arm arm;
+  
+    public ResetEncoderPosition(Arm arm) {
+      requires(arm);
+      this.arm = arm;
+    }
+  
+    @Override
+    protected void initialize() {
+      arm.resetElevatorPosition();
+    }
+  
+  }

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -19,6 +19,7 @@ import frc.robot.RobotMap;
 import frc.robot.OI;
 import frc.robot.RobotMap.DeadbandType;
 import frc.robot.commands.defaults.Articulate;
+import frc.robot.commands.test.ResetEncoderPosition;
 
 /**
  * Add your docs here.
@@ -80,7 +81,7 @@ public class Arm extends Subsystem {
     return wrist.getEncoder().getPosition() - resetWristEncoderPosition;
   }
 
-  private void resetElevatorPosition() {
+  public void resetElevatorPosition() {
     resetElbowEncoderPosition = elbow.getEncoder().getPosition();
     resetWristEncoderPosition = wrist.getEncoder().getPosition();
   }
@@ -96,8 +97,11 @@ public class Arm extends Subsystem {
   public double gravBreak(double encoder, double controlIn) {
     if ((Math.abs(controlIn) <= .05)) {
       lastEncoder = encoder;
-      return (lastEncoder - encoder / encoder);
+      double outputGravBreak; 
+      outputGravBreak = (lastEncoder - encoder / encoder);
+      return outputGravBreak;
     }
+    return 0; //This was all we needed
   }
 }
 
@@ -110,18 +114,4 @@ public class Arm extends Subsystem {
 // }
 // }
 
-private class ResetEncoderPosition extends InstantCommand {
 
-  private Arm arm;
-
-  public ResetEncoderPosition(Arm arm) {
-    requires(arm);
-    this.arm = arm;
-  }
-
-  @Override
-  protected void initialize() {
-    arm.resetElevatorPosition();
-  }
-
-}


### PR DESCRIPTION
Turns out we forgot to add an extra return after the if statement.

https://stackoverflow.com/questions/42976238/java-error-this-method-must-return-a-result-of-type-string-occurs-without-reas

The compiler realized that there's a possibility that the function could return no value (if the value was not <= 0.05) which meant that it threw the error. Really wish the error was better, but I guess that works now.

The other error was fixed by moving it to it's own file. There's probably a better way of doing this than leaving it in test so we'll do that later.